### PR TITLE
Rails 6 compatibility

### DIFF
--- a/lib/regulator.rb
+++ b/lib/regulator.rb
@@ -71,8 +71,15 @@ module Regulator
   end
 
   included do
-    def self.policy_namespace
-      ( self.parent != Object ? self.parent : nil )
+    # Rails 6 renamed .parent to .module_parent
+    if respond_to?(:module_parent)
+      def self.policy_namespace
+        ( self.module_parent != Object ? self.module_parent : nil )
+      end
+    else
+      def self.policy_namespace
+        ( self.parent != Object ? self.parent : nil )
+      end
     end
 
     def policy_namespace

--- a/lib/regulator/policy_finder.rb
+++ b/lib/regulator/policy_finder.rb
@@ -30,7 +30,12 @@ module Regulator
           # if the controller explicitly sets the policy_namespace to we want to keep it nil
           @controller.try(:policy_namespace)
         else
-          @controller.class.parent
+          # Rails 6 renamed .parent to .module_parent
+          if @controller.class.respond_to?(:module_parent)
+            @controller.class.module_parent
+          else
+            @controller.class.parent
+          end
         end
       end
     end


### PR DESCRIPTION
Rails 6 deprecated `.parent` in favour of `.module_parent`. It’s currently a soft deprecation generating warnings. In 6.1 the `.parent` method will be completely removed.

Adding specs to test this properly implies testing the repo on multiple versions of rails. If that's important I could look into setting something on via multiple Gemfiles + `.travis.yml` but considering this is such a low maintenance project maybe it's ok to just get this merged and publishing a new gem version?

For now I've manually tested it in 5.x and 6.x by playing around with different values in the gemspec so I can vouch for the code working.